### PR TITLE
Update supported framework runtime to include .NET 4.6

### DIFF
--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -28,7 +28,7 @@
         <Edition>Pro</Edition>
       </VisualStudio>
     </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.5" MaxVersion="4.5" />
+    <SupportedFrameworkRuntimeEdition MinVersion="4.5" MaxVersion="4.6" />
     <AllUsers>false</AllUsers>
   </Identifier>
   <References />

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -28,7 +28,7 @@
         <Edition>Pro</Edition>
       </VisualStudio>
     </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.5" MaxVersion="4.6" />
+    <SupportedFrameworkRuntimeEdition MinVersion="4.5" />
     <AllUsers>false</AllUsers>
   </Identifier>
   <References />


### PR DESCRIPTION
When Visual Studio 2015 CTP is installed .NET 4.5.1 is upgraded to .NET 4.5.3 (4.6) this causes the package not to install even on Visual Studio 2013.