### PR TITLE
Fixed asyncmethodhandler to detect async overloaded methods 

### DIFF
--- a/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
+++ b/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
@@ -24,7 +24,7 @@ namespace NUnit.VisualStudio.TestAdapter.Internal
             var definingType = targetAssembly.GetType(className);
             if (definingType == null) return null;
 
-            var method = definingType.GetMethod(methodName);
+            var method = definingType.GetMethods().Where(o=>o.Name==methodName).OrderBy(o=>o.GetParameters().Length).FirstOrDefault();
             if (method == null) return null;
 
             var asyncAttribute = GetAsyncStateMachineAttribute(method);

--- a/src/NUnitTestAdapter/NUnitTestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnitTestDiscoverer.cs
@@ -1,8 +1,11 @@
 ﻿// ****************************************************************
 // Copyright (c) 2011 NUnit Software. All rights reserved.
 // ****************************************************************
-
+// #define LAUNCHDEBUGGER
 using System.Collections.Generic;
+#if LAUNCHDEBUGGER
+using System.Diagnostics;
+#endif
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.4")]
+[assembly: AssemblyFileVersion("2.1.0.4")]

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="NUnitTestAdapterInstall..7c53286e-ac4f-485f-915c-5ec5a4c47b0c">
     <Name>NUnit Test Adapter</Name>
     <Author>Charlie Poole</Author>
-    <Version>2.0.0.0</Version>
+    <Version>2.1.0.4</Version>
     <Description xml:space="preserve">NUnit adapter for integrated test execution under Visual Studio 2012 (all updates), Visual Studio 2013 (all updates), and the Visual Studio 2015 Preview and CTPs. Compatible with NUnit 2.0 through 2.6.4.</Description>
     <Locale>1033</Locale>
     <MoreInfoUrl>http://nunit.org/index.php?p=vsTestAdapter&amp;r=2.6.4</MoreInfoUrl>


### PR DESCRIPTION
without crashing  #87.

Ensured that the async handling is identical to the non-async handling, returning the non-parametrized method as the navigation source. 