### PR TITLE
Avoid UnsupportedFrameworkException case of Nunit3 Tests

### DIFF
--- a/src/NUnitTestAdapter/AssemblyRunner.cs
+++ b/src/NUnitTestAdapter/AssemblyRunner.cs
@@ -138,6 +138,11 @@ namespace NUnit.VisualStudio.TestAdapter
                 // Probably from the GetExportedTypes in NUnit.core, attempting to find an assembly, not a problem if it is not NUnit here
                 logger.DependentAssemblyNotFoundWarning(ex.FileName, assemblyName);
             }
+            catch (UnsupportedFrameworkException ex)
+            {
+                //The UnsupportedFrameworkException is inside nunit only thrown, if the found test-nunit-version is larger than the installed nunit-adapter-version
+                logger.SendInformationalMessage("File has wrong Nunit version "+ assemblyName);
+            }
             catch (Exception ex)
             {
                 logger.SendErrorMessage("Exception thrown executing tests in " + assemblyName, ex);


### PR DESCRIPTION
If Nunit2 tries to run a Nunit3 assembly, a UnsupportedFrameworkException is thrown (insude Nunit 2.6.4). Due to this, VS interprets Nunit3 tests (performed by Nunit2) as 'failed'.

This fix leads to, that VS (running Nunit2) ignores Nunit3 test results.