### PR TITLE
Adding Installation target support for Visual Studio 2017 (14.0) Community, Pro, Enterprise

### DIFF
--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,16.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[11.0,16.0)"/>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,16.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,16.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,16.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
The NUnit 2.X version of the NUnit Test Adapter will not install on Visual Studio 2017 (to be released March 7th, 2017).  For users that wish to continue using a 2.X version of NUnit they will need to use this older NUnit test runner.