### PR TITLE
Added searchdirectories to the navigation  #143 #147

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.1.{build}
+version: 2.2.{build}
 image: Visual Studio 2015
 
 build_script:

--- a/build.cake
+++ b/build.cake
@@ -9,8 +9,8 @@ var configuration = Argument("configuration", "Debug");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "2.1.1";
-var modifier = "";
+var version = "2.1.2";
+var modifier = "-a001";
 
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
 var packageVersion = version + modifier + dbgSuffix;

--- a/build.cake
+++ b/build.cake
@@ -9,8 +9,8 @@ var configuration = Argument("configuration", "Debug");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "2.1.2";
-var modifier = "-a001";
+var version = "2.2.0";
+var modifier = "";
 
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
 var packageVersion = version + modifier + dbgSuffix;

--- a/src/NUnitTestAdapter/NavigationDataProvider.cs
+++ b/src/NUnitTestAdapter/NavigationDataProvider.cs
@@ -43,8 +43,7 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 methodDef = typeDef
                     .GetMethods()
-                    .Where(o => o.Name == methodName)
-                    .FirstOrDefault();
+                    .FirstOrDefault(o => o.Name == methodName);
 
                 if (methodDef != null)
                     break;
@@ -52,8 +51,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 var baseType = typeDef.BaseType;
                 if (baseType == null || baseType.FullName == "System.Object")
                     return NavigationData.Invalid;
-
-                typeDef = typeDef.BaseType.Resolve();
+               typeDef = typeDef.BaseType.Resolve();
             }
 
             var sequencePoint = FirstOrDefaultSequencePoint(methodDef);
@@ -77,14 +75,27 @@ namespace NUnit.VisualStudio.TestAdapter
 
         static IDictionary<string, TypeDefinition> CacheTypes(string assemblyPath)
         {
+            var paths = new List<string>();
+            var resolver = new DefaultAssemblyResolver();
+            var path = Path.GetDirectoryName(assemblyPath);
+            paths.Add(path);
+            resolver.AddSearchDirectory(path);
              var readsymbols = DoesPdbFileExist(assemblyPath);
-            var readerParameters = new ReaderParameters() { ReadSymbols = readsymbols };
+            var readerParameters = new ReaderParameters { ReadSymbols = readsymbols,AssemblyResolver = resolver};
             var module = ModuleDefinition.ReadModule(assemblyPath, readerParameters);
 
             var types = new Dictionary<string, TypeDefinition>();
 
             foreach (var type in module.GetTypes())
+            {
+                var directory = Path.GetDirectoryName(type.Module.FullyQualifiedName);
+                if (!paths.Contains(directory))
+                {
+                    resolver.AddSearchDirectory(directory);
+                    paths.Add(directory);
+                }
                 types[type.FullName] = type;
+            }
 
             return types;
         }

--- a/src/NUnitTestAdapter/NavigationDataProvider.cs
+++ b/src/NUnitTestAdapter/NavigationDataProvider.cs
@@ -80,7 +80,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var path = Path.GetDirectoryName(assemblyPath);
             paths.Add(path);
             resolver.AddSearchDirectory(path);
-             var readsymbols = DoesPdbFileExist(assemblyPath);
+            var readsymbols = DoesPdbFileExist(assemblyPath);
             var readerParameters = new ReaderParameters { ReadSymbols = readsymbols,AssemblyResolver = resolver};
             var module = ModuleDefinition.ReadModule(assemblyPath, readerParameters);
 

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NUnitTestAdapterInstall..7c53286e-ac4f-485f-915c-5ec5a4c47b0c" Version="2.1.1" Language="en-US" Publisher="Charlie Poole" />
+    <Identity Id="NUnitTestAdapterInstall..7c53286e-ac4f-485f-915c-5ec5a4c47b0c" Version="2.1.1.1" Language="en-US" Publisher="Charlie Poole" />
     <DisplayName>NUnit 2 Test Adapter</DisplayName>
     <Description xml:space="preserve">NUnit 2 adapter for running tests in Visual Studio 2012 and newer. Works with NUnit 2.x, for 3.x tests use the NUnit 3 adapter.</Description>
     <MoreInfo>https://github.com/nunit/docs/wiki/VS-Adapter</MoreInfo>

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NUnitTestAdapterInstall..7c53286e-ac4f-485f-915c-5ec5a4c47b0c" Version="2.1.1.1" Language="en-US" Publisher="Charlie Poole" />
+    <Identity Id="NUnitTestAdapterInstall..7c53286e-ac4f-485f-915c-5ec5a4c47b0c" Version="2.2.0.0" Language="en-US" Publisher="Charlie Poole" />
     <DisplayName>NUnit 2 Test Adapter</DisplayName>
     <Description xml:space="preserve">NUnit 2 adapter for running tests in Visual Studio 2012 and newer. Works with NUnit 2.x, for 3.x tests use the NUnit 3 adapter.</Description>
     <MoreInfo>https://github.com/nunit/docs/wiki/VS-Adapter</MoreInfo>


### PR DESCRIPTION

Bugfix for the #143 and #147 issues on finding the correct assemblies when running inherited tests in other projects.  

Finds the assembly paths of those involved, and adds them to the navigation resolvers search-directories. 