### PR TITLE
Deploy nuget package to myget when master is merged

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,3 +11,12 @@ artifacts:
 - path: package\*.nupkg
 - path: package\*.vsix
 - path: package\*.zip
+
+deploy:
+  - provider: NuGet
+    server: https://www.myget.org/F/nunit/api/v2
+    api_key:
+      secure: wtAvJDVl2tfwiVcyLExFHLvZVfUWiQRHsfdHBFCNEATeCHo1Nd8JP642PfY8xhji
+    skip_symbols: true
+    on:
+      branch: master

--- a/build.cake
+++ b/build.cake
@@ -26,7 +26,7 @@ if (BuildSystem.IsRunningOnAppVeyor)
 	else
 	{
 		var buildNumber = AppVeyor.Environment.Build.Number.ToString("00000");
-		var branch = AppVeyor.Environment.Repository.Branch;
+		var branch = AppVeyor.Environment.Repository.Branch.Replace(".", "").Replace("/", "");
 		var isPullRequest = AppVeyor.Environment.PullRequest.IsPullRequest;
 
 		if (branch == "master" && !isPullRequest)


### PR DESCRIPTION
Fixes #152 

This has to be merged in order to see the change actually work. Upon merge, it should rebuild master and then deploy the nuget package to MyGet.

Also cleaned up the branch name in build.cake to match NUnit 3 adapter.