### PR TITLE
Ported CollectSourceInformation setting from v3 Adapter to v2

### DIFF
--- a/src/NUnitTestAdapter/AssemblyRunner.cs
+++ b/src/NUnitTestAdapter/AssemblyRunner.cs
@@ -54,19 +54,19 @@ namespace NUnit.VisualStudio.TestAdapter
         #region Constructors
 
         // This constructor is called by the others and is used directly for testing
-        public AssemblyRunner(TestLogger logger, string assemblyName, INUnitTestAdapter nunitTestAdapter)
+        public AssemblyRunner(TestLogger logger, string assemblyName, INUnitTestAdapter nunitTestAdapter, bool collectSourceInformation)
         {
             this.logger = logger;
             this.assemblyName = assemblyName;
-            testConverter = new TestConverter(logger, assemblyName);
+            testConverter = new TestConverter(logger, assemblyName, collectSourceInformation);
             loadedTestCases = new List<TestCase>();
             nunitFilter = TestFilter.Empty;
             NUnitTestAdapter = nunitTestAdapter;
         }
 
         // This constructor is used when the executor is called with a list of test cases
-        public AssemblyRunner(TestLogger logger, string assemblyName, IEnumerable<TestCase> selectedTestCases, INUnitTestAdapter nunitTestAdapter)
-            : this(logger, assemblyName, nunitTestAdapter)
+        public AssemblyRunner(TestLogger logger, string assemblyName, IEnumerable<TestCase> selectedTestCases, INUnitTestAdapter nunitTestAdapter, bool collectSourceInformation)
+            : this(logger, assemblyName, nunitTestAdapter, collectSourceInformation)
         {
             nunitFilter = MakeTestFilter(selectedTestCases);
         }
@@ -74,8 +74,8 @@ namespace NUnit.VisualStudio.TestAdapter
         private readonly ITfsTestFilter tfsFilter;
 
         // This constructor is used when the executor is called with a list of assemblies
-        public AssemblyRunner(TestLogger logger, string assemblyName, ITfsTestFilter tfsFilter, INUnitTestAdapter nunitTestAdapter)
-            : this(logger, assemblyName, nunitTestAdapter)
+        public AssemblyRunner(TestLogger logger, string assemblyName, ITfsTestFilter tfsFilter, INUnitTestAdapter nunitTestAdapter, bool collectSourceInformation)
+            : this(logger, assemblyName, nunitTestAdapter, collectSourceInformation)
         {
             this.tfsFilter = tfsFilter;
         }

--- a/src/NUnitTestAdapter/NUnitTestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnitTestDiscoverer.cs
@@ -50,6 +50,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger messageLogger, ITestCaseDiscoverySink discoverySink)
         {
             TestLog.Initialize(messageLogger);
+            Initialize(discoveryContext);
             if (RegistryFailure)
             {
                 TestLog.SendErrorMessage(ErrorMsg);
@@ -70,7 +71,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     if (runner.Load(package))
                     {
-                        testConverter = new TestConverter(TestLog, sourceAssembly);
+                        testConverter = new TestConverter(TestLog, sourceAssembly, CollectSourceInformation);
                         int cases = ProcessTestCases(runner.Test, discoverySink, testConverter);
                         TestLog.SendDebugMessage(string.Format("Discovered {0} test cases", cases));
                     }

--- a/src/NUnitTestAdapter/NUnitTestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnitTestExecutor.cs
@@ -57,6 +57,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             TestLog.Initialize(frameworkHandle);
+            Initialize(runContext);
             if (RegistryFailure)
             {
                 TestLog.SendErrorMessage(ErrorMsg);
@@ -83,7 +84,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     if (!Path.IsPathRooted(sourceAssembly))
                         sourceAssembly = Path.Combine(Environment.CurrentDirectory, sourceAssembly);
 
-                    currentRunner = new AssemblyRunner(TestLog, sourceAssembly, tfsfilter, this);
+                    currentRunner = new AssemblyRunner(TestLog, sourceAssembly, tfsfilter, this, CollectSourceInformation);
                     currentRunner.RunAssembly(frameworkHandle);
                 }
             }
@@ -111,6 +112,7 @@ namespace NUnit.VisualStudio.TestAdapter
 #endif
 
             TestLog.Initialize(frameworkHandle);
+            Initialize(runContext);
             if (RegistryFailure)
             {
                 TestLog.SendErrorMessage(ErrorMsg);
@@ -126,7 +128,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var assemblyGroups = tests.GroupBy(tc => tc.Source);
             foreach (var assemblyGroup in assemblyGroups)
             {
-                currentRunner = new AssemblyRunner(TestLog, assemblyGroup.Key, assemblyGroup, this);
+                currentRunner = new AssemblyRunner(TestLog, assemblyGroup.Key, assemblyGroup, this, CollectSourceInformation);
                 currentRunner.RunAssembly(frameworkHandle);
             }
 

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -40,15 +40,20 @@ namespace NUnit.VisualStudio.TestAdapter
         private readonly Dictionary<string, TestCase> _vsTestCaseMap;
         private readonly string _sourceAssembly;
         private NavigationDataProvider _navigationDataProvider;
+        private bool _collectSourceInformation;
 
         #region Constructor
 
-        public TestConverter(TestLogger logger, string sourceAssembly)
+        public TestConverter(TestLogger logger, string sourceAssembly, bool collectSourceInformation)
         {
             _logger = logger;
             _sourceAssembly = sourceAssembly;
             _vsTestCaseMap = new Dictionary<string, TestCase>();
-            _navigationDataProvider = new NavigationDataProvider(sourceAssembly);
+            _collectSourceInformation = collectSourceInformation;
+            if (_collectSourceInformation)
+            {
+                _navigationDataProvider = new NavigationDataProvider(sourceAssembly);
+            }
         }
 
         #endregion
@@ -140,11 +145,14 @@ namespace NUnit.VisualStudio.TestAdapter
                 LineNumber = 0
             };
 
-            var navData = _navigationDataProvider.GetNavigationData(nunitTest.ClassName, nunitTest.MethodName);
-            if (navData.IsValid)
+            if (_collectSourceInformation && _navigationDataProvider != null)
             {
-                testCase.CodeFilePath = navData.FilePath;
-                testCase.LineNumber = navData.LineNumber;
+                var navData = _navigationDataProvider.GetNavigationData(nunitTest.ClassName, nunitTest.MethodName);
+                if (navData.IsValid)
+                {
+                    testCase.CodeFilePath = navData.FilePath;
+                    testCase.LineNumber = navData.LineNumber;
+                }
             }
 
             testCase.AddTraitsFromNUnitTest(nunitTest);

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
@@ -71,7 +71,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
 
         IRunSettings IDiscoveryContext.RunSettings
         {
-            get { throw new NotImplementedException(); }
+            get { return new FakeRunSettings(); }
         }
 
         #endregion

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
@@ -35,7 +35,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
 
         public string SettingsXml
         {
-            get { throw new NotImplementedException(); }
+            get { return string.Empty; }
         }
     }
 }

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
             testLog = new FakeFrameworkHandle();
 
-            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath);
+            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath, true);
 
             testConverter.ConvertTestCase(fakeNUnitTest);
             Assert.NotNull(testConverter.GetCachedTestCase(fakeNUnitTest.TestName.UniqueName));
@@ -198,7 +198,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void Listener_LeaseLifetimeWillNotExpire()
         {
             testLog = new FakeFrameworkHandle();
-            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath);
+            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath, true);
             MarshalByRefObject localInstance = (MarshalByRefObject)Activator.CreateInstance(typeof(NUnitEventListener), testLog, testConverter);
 
             RemotingServices.Marshal(localInstance);

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -68,7 +68,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             var fixtureNode = new TestNode(nunitFixture);
             fakeNUnitTest = (ITest)fixtureNode.Tests[0];
 
-            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath);
+            testConverter = new TestConverter(new TestLogger(), ThisAssemblyPath, true);
         }
 
         [Test]


### PR DESCRIPTION
Here is original PR: https://github.com/nunit/nunit3-vs-adapter/pull/350

I didn't want to introduce many changes like adding whole AdapterSettings class, hence I just added CollectSourceInformation property to NUnitTestAdapter class and added same Initialize method as v3 NUnitTestAdapter has and call it with `context` parameter from Discovery/Executor subclass so CollectSourceInformation can be extracted from xml settings.
Logic of obtaining extracting CollectSourceInformation from SettingsXml is same as in v3 of Adapter.
Changes in TestConverter are identical to changes in v3.
I changed unit tests just enough so they keep compiling since API changed a bit.